### PR TITLE
Remove max_results parameter from run_query tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,6 @@ All configuration can be set via CLI arguments or environment variables. CLI arg
 --datasets dataset1 dataset2    # Restrict to specific datasets (default: all datasets)
 
 # Query & Result Limits
---max-results 20                # Max rows returned by run_query (default: 20)
 --list-max-results 500          # Max results for basic list operations (default: 500)
 --detailed-list-max 25          # Max results for detailed list operations (default: 25)
 
@@ -119,7 +118,6 @@ All CLI options have corresponding environment variables:
 export GCP_PROJECT_ID=your-project
 export BIGQUERY_LOCATION=US
 export BIGQUERY_ALLOWED_DATASETS=dataset1,dataset2
-export BIGQUERY_MAX_RESULTS=20
 export BIGQUERY_LIST_MAX_RESULTS=500
 export BIGQUERY_LIST_MAX_RESULTS_DETAILED=25
 export BIGQUERY_SAMPLE_ROWS=3
@@ -137,7 +135,7 @@ This MCP server provides 4 core BigQuery tools optimized for LLM efficiency:
 - **`get_table`** - Complete table analysis with schema and sample data
 
 ### 🔍 Safe Query Execution
-- **`run_query`** - Execute SELECT/WITH queries only, with cost tracking and safety validation
+- **`run_query`** - Execute SELECT/WITH queries only, with cost tracking and safety validation. Use LIMIT clause in queries to control result size.
 
 **Key Features:**
 - ✅ **Minimal by default** - 70% fewer tokens in basic mode
@@ -216,6 +214,7 @@ SELECT
 FROM `bigquery-public-data.new_york_taxi_trips.tlc_yellow_trips_2020`
 WHERE pickup_datetime BETWEEN '2020-01-01' AND '2020-12-31'
 GROUP BY year
+LIMIT 20
 ```
 
 ### 🤖 Example: Usage with Claude Code subagent

--- a/src/bigquery_mcp/server.py
+++ b/src/bigquery_mcp/server.py
@@ -35,7 +35,6 @@ Environment Variables (can be overridden by CLI arguments):
   BIGQUERY_LOCATION                 BigQuery location (e.g., 'US', 'EU', 'us-central1')
   GOOGLE_APPLICATION_CREDENTIALS    Path to service account key file
   BIGQUERY_ALLOWED_DATASETS         Comma-separated list of allowed datasets
-  BIGQUERY_MAX_RESULTS              Max results for queries (default: 20)
   BIGQUERY_LIST_MAX_RESULTS         Max results for basic list operations (default: 500)
   BIGQUERY_LIST_MAX_RESULTS_DETAILED Max results for detailed list operations (default: 25)
   BIGQUERY_SAMPLE_ROWS              Sample data rows in table details (default: 3)
@@ -83,13 +82,6 @@ Examples:
     )
 
     parser.add_argument(
-        "--max-results",
-        type=int,
-        dest="max_results",
-        help="Max rows returned by run_query (default: 20)",
-    )
-
-    parser.add_argument(
         "--list-max-results",
         type=int,
         dest="list_max_results",
@@ -128,7 +120,6 @@ Examples:
 
 
 def _set_environment_overrides(
-    max_results: int | None = None,
     list_max_results: int | None = None,
     detailed_list_max: int | None = None,
     sample_rows: int | None = None,
@@ -137,9 +128,6 @@ def _set_environment_overrides(
     allowed_datasets: list[str] | None = None,
 ) -> None:
     """Set environment variables for configuration overrides."""
-    if max_results is not None:
-        os.environ["BIGQUERY_MAX_RESULTS"] = str(max_results)
-
     if list_max_results is not None:
         os.environ["BIGQUERY_LIST_MAX_RESULTS"] = str(list_max_results)
 
@@ -163,7 +151,6 @@ def run_server(
     project_id: str,
     location: str,
     key_file: str | None = None,
-    max_results: int | None = None,
     list_max_results: int | None = None,
     detailed_list_max: int | None = None,
     sample_rows: int | None = None,
@@ -177,7 +164,6 @@ def run_server(
         project_id: Google Cloud project ID
         location: BigQuery location
         key_file: Optional path to service account key file
-        max_results: Optional override for query max results
         list_max_results: Optional override for basic list max results
         detailed_list_max: Optional override for detailed list max results
         sample_rows: Optional override for sample data rows
@@ -187,7 +173,6 @@ def run_server(
     """
     # Set environment variables for configuration overrides
     _set_environment_overrides(
-        max_results=max_results,
         list_max_results=list_max_results,
         detailed_list_max=detailed_list_max,
         sample_rows=sample_rows,
@@ -287,7 +272,6 @@ def main() -> None:
             project_id=project_id,
             location=location,
             key_file=args.key_file,
-            max_results=args.max_results,
             list_max_results=args.list_max_results,
             detailed_list_max=args.detailed_list_max,
             sample_rows=args.sample_rows,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -95,7 +95,6 @@ def test_allowed_datasets_empty_env_var():
 @pytest.mark.parametrize(
     "arg_name,env_var,expected_type",
     [
-        ("max_results", "BIGQUERY_MAX_RESULTS", int),
         ("list_max_results", "BIGQUERY_LIST_MAX_RESULTS", int),
         ("detailed_list_max", "BIGQUERY_LIST_MAX_RESULTS_DETAILED", int),
         ("sample_rows", "BIGQUERY_SAMPLE_ROWS", int),
@@ -126,11 +125,9 @@ def test_cli_argument_precedence():
     from bigquery_mcp.server import parse_arguments
 
     # Set environment variables
-    with patch.dict(
-        os.environ, {"GCP_PROJECT_ID": "env-project", "BIGQUERY_LOCATION": "env-location", "BIGQUERY_MAX_RESULTS": "50"}
-    ):
+    with patch.dict(os.environ, {"GCP_PROJECT_ID": "env-project", "BIGQUERY_LOCATION": "env-location"}):
         # Mock command line arguments that override env vars
-        test_args = ["--project", "cli-project", "--location", "cli-location", "--max-results", "100"]
+        test_args = ["--project", "cli-project", "--location", "cli-location"]
 
         with patch("sys.argv", ["bigquery-mcp", *test_args]):
             args = parse_arguments()
@@ -138,7 +135,6 @@ def test_cli_argument_precedence():
             # CLI args should override environment
             assert args.project_id == "cli-project"
             assert args.location == "cli-location"
-            assert args.max_results == 100
 
 
 def test_configuration_defaults(env_vars):
@@ -146,13 +142,11 @@ def test_configuration_defaults(env_vars):
     from bigquery_mcp.bigquery_tools import (
         DEFAULT_LIST_MAX_RESULTS,
         DEFAULT_LIST_MAX_RESULTS_DETAILED,
-        DEFAULT_MAX_RESULTS,
         DEFAULT_SAMPLE_ROWS,
         DEFAULT_SAMPLE_ROWS_FOR_STATS,
     )
 
     # Test that defaults are reasonable values
-    assert DEFAULT_MAX_RESULTS == 20
     assert DEFAULT_LIST_MAX_RESULTS == 500
     assert DEFAULT_LIST_MAX_RESULTS_DETAILED == 25
     assert DEFAULT_SAMPLE_ROWS == 3

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -104,7 +104,6 @@ class TestBigQueryMCPIntegration:
             ORDER BY word_count DESC
             LIMIT 5
             """,
-                "max_results": 10,
             },
         )
 
@@ -314,7 +313,6 @@ class TestBigQueryMCPIntegration:
             "run_query",
             {
                 # Missing required 'query' parameter
-                "max_results": 10
             },
         )
 
@@ -336,8 +334,8 @@ class TestBigQueryMCPIntegration:
             SELECT word, word_count, corpus
             FROM `bigquery-public-data.samples.shakespeare`
             ORDER BY word_count DESC
+            LIMIT 100
             """,
-                "max_results": 100,  # Limit results
             },
         )
 


### PR DESCRIPTION
- Remove max_results parameter from run_query tool completely
- Update tool description to recommend using LIMIT clause in SQL queries
- Remove all CLI arguments and environment variables related to query max_results
- Update tests to remove max_results usage and use LIMIT in SQL instead
- Improve list tools documentation to clarify max_results is optional integer

The run_query tool now relies on SQL LIMIT clause for result control, making it more explicit and giving users full control over result size.