### PR TITLE
feat: cap BigQuery query spend with maximum_bytes_billed

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ All configuration can be set via CLI arguments or environment variables. CLI arg
 # Query & Result Limits
 --list-max-results 500          # Max results for basic list operations (default: 500)
 --detailed-list-max 25          # Max results for detailed list operations (default: 25)
+--max-bytes-billed 109951162777  # Max bytes billed per query job (~USD 0.50/query)
 
 # Table Analysis
 --sample-rows 3                 # Sample data rows returned in get_table (default: 3)
@@ -121,6 +122,7 @@ export BIGQUERY_LOCATION=US
 export BIGQUERY_ALLOWED_DATASETS=dataset1,dataset2
 export BIGQUERY_LIST_MAX_RESULTS=500
 export BIGQUERY_LIST_MAX_RESULTS_DETAILED=25
+export BIGQUERY_MAX_BYTES_BILLED=109951162777
 export BIGQUERY_SAMPLE_ROWS=3
 export BIGQUERY_SAMPLE_ROWS_FOR_STATS=500
 export GOOGLE_APPLICATION_CREDENTIALS=/path/to/key.json
@@ -144,7 +146,7 @@ This MCP server provides 5 BigQuery tools optimized for LLM efficiency:
 - **`get_table`** - Complete table analysis with schema and sample data
 
 ### 🔍 Safe Query Execution
-- **`run_query`** - Execute SELECT/WITH queries only, with cost tracking and safety validation. Use LIMIT clause in queries to control result size.
+- **`run_query`** - Execute SELECT/WITH queries only, with cost tracking, safety validation, and a default per-query billing cap of about USD 0.50. Use LIMIT clause in queries to control result size.
 
 ### 🔮 Vector Search (Optional)
 - **`vector_search`** - Dual-mode tool: discover embedding tables (no query_text) or perform semantic similarity search (with query_text)
@@ -154,6 +156,7 @@ This MCP server provides 5 BigQuery tools optimized for LLM efficiency:
 - ✅ **Safe queries only** - Blocks all write operations
 - ✅ **LLM-optimized** - Returns structured data perfect for AI analysis
 - ✅ **Cost transparent** - Shows bytes processed for each query
+- ✅ **Cost bounded by default** - Caps each query job at about USD 0.50 unless reconfigured
 
 ## 🔮 Vector Search (Optional)
 

--- a/src/bigquery_mcp/bigquery_tools.py
+++ b/src/bigquery_mcp/bigquery_tools.py
@@ -30,6 +30,7 @@ DEFAULT_LIST_MAX_RESULTS_DETAILED = 25  # When including descriptions, limit for
 DEFAULT_SAMPLE_ROWS = 3  # Number of sample rows to include in table details
 DEFAULT_SAMPLE_ROWS_FOR_STATS = 500  # Number of rows to sample for column statistics
 DEFAULT_MAX_RECOMMENDED_RESULTS = 1000  # Maximum recommended results to prevent context overflow
+DEFAULT_MAX_BYTES_BILLED = 109_951_162_777  # ~0.50 USD/query at 5 USD per TiB scanned
 
 # These can be overridden by environment variables or CLI arguments
 _list_max_results = int(os.getenv("BIGQUERY_LIST_MAX_RESULTS", str(DEFAULT_LIST_MAX_RESULTS)))
@@ -59,6 +60,29 @@ def get_table_sample_data_rows() -> int:
 def get_query_max_recommended_results() -> int:
     """Get maximum recommended results for query execution."""
     return _max_recommended_results
+
+
+def get_query_max_bytes_billed() -> int:
+    """Get maximum bytes billed for a single query job."""
+    return int(os.getenv("BIGQUERY_MAX_BYTES_BILLED", str(DEFAULT_MAX_BYTES_BILLED)))
+
+
+def _create_query_job_config(
+    *,
+    query_parameters: list[bigquery.ScalarQueryParameter] | None = None,
+    dry_run: bool = False,
+    use_query_cache: bool | None = None,
+) -> bigquery.QueryJobConfig:
+    """Create a query job config with the billing cap applied."""
+    job_config = bigquery.QueryJobConfig(
+        maximum_bytes_billed=get_query_max_bytes_billed(),
+        dry_run=dry_run,
+    )
+    if query_parameters is not None:
+        job_config.query_parameters = query_parameters
+    if use_query_cache is not None:
+        job_config.use_query_cache = use_query_cache
+    return job_config
 
 
 # Vector search configuration
@@ -224,7 +248,7 @@ def _calculate_column_fill_rates(
     """  # noqa: S608
 
     try:
-        query_job = bigquery_client.query(query)
+        query_job = bigquery_client.query(query, job_config=_create_query_job_config())
         results = list(query_job.result())
 
         if not results:
@@ -287,7 +311,7 @@ def register_tools(  # noqa: C901
             if not is_safe:
                 return _create_error_response(Exception(error_msg))
 
-            query_job = bigquery_client.query(query)
+            query_job = bigquery_client.query(query, job_config=_create_query_job_config())
             results = await asyncio.to_thread(query_job.result)
 
             rows = [dict(row) for row in results]
@@ -297,6 +321,7 @@ def register_tools(  # noqa: C901
                 total_count=len(rows),
                 total_rows_in_result=results.total_rows,
                 bytes_processed=query_job.total_bytes_processed,
+                max_bytes_billed=get_query_max_bytes_billed(),
             )
 
         except (GoogleCloudError, Exception) as e:
@@ -536,7 +561,7 @@ def register_tools(  # noqa: C901
                 order_clause = f"ORDER BY `{timestamp_columns[0]}` DESC" if timestamp_columns else ""
 
                 sample_query = f"SELECT * FROM `{table_path}` {order_clause} LIMIT {sample_rows_count}"  # noqa: S608
-                query_job = bigquery_client.query(sample_query)
+                query_job = bigquery_client.query(sample_query, job_config=_create_query_job_config())
                 results = await asyncio.to_thread(query_job.result)
                 sample_data = [dict(row) for row in results]
             except Exception:
@@ -616,7 +641,8 @@ def register_tools(  # noqa: C901
 
         query += " ORDER BY table_schema, table_name, column_name"
 
-        results = await asyncio.to_thread(bigquery_client.query(query).result)
+        query_job = bigquery_client.query(query, job_config=_create_query_job_config())
+        results = await asyncio.to_thread(query_job.result)
 
         tables_dict: dict[str, dict[str, Any]] = {}
         for row in results:
@@ -720,7 +746,7 @@ def register_tools(  # noqa: C901
         ORDER BY distance
         """  # noqa: S608
 
-        job_config = bigquery.QueryJobConfig(
+        job_config = _create_query_job_config(
             query_parameters=[bigquery.ScalarQueryParameter("query_text", "STRING", query_text)]
         )
 
@@ -740,6 +766,7 @@ def register_tools(  # noqa: C901
             embedding_model=model,
             distance_type=distance_type.upper(),
             bytes_processed=query_job.total_bytes_processed,
+            max_bytes_billed=get_query_max_bytes_billed(),
             sql_query=reusable_query,
         )
 

--- a/src/bigquery_mcp/server.py
+++ b/src/bigquery_mcp/server.py
@@ -39,6 +39,7 @@ Environment Variables (can be overridden by CLI arguments):
   BIGQUERY_LIST_MAX_RESULTS_DETAILED Max results for detailed list operations (default: 25)
   BIGQUERY_SAMPLE_ROWS              Sample data rows in table details (default: 3)
   BIGQUERY_SAMPLE_ROWS_FOR_STATS    Rows sampled for fill rates (default: 500)
+  BIGQUERY_MAX_BYTES_BILLED         Max bytes billed per query job (default: 109951162777, ~USD 0.50)
   BIGQUERY_EMBEDDING_MODEL          BigQuery ML embedding model path
   BIGQUERY_EMBEDDING_TABLES         Comma-separated tables with embeddings
   BIGQUERY_EMBEDDING_COLUMN_CONTAINS Pattern for finding embedding columns (default: 'embedding')
@@ -115,6 +116,13 @@ Examples:
     )
 
     parser.add_argument(
+        "--max-bytes-billed",
+        type=int,
+        dest="max_bytes_billed",
+        help="Max bytes billed per query job (default: 109951162777, about USD 0.50/query)",
+    )
+
+    parser.add_argument(
         "--vector-search",
         "--no-vector-search",
         dest="vector_search_enabled",
@@ -164,6 +172,7 @@ def _set_environment_overrides(
     detailed_list_max: int | None = None,
     sample_rows: int | None = None,
     stats_sample_size: int | None = None,
+    max_bytes_billed: int | None = None,
     key_file: str | None = None,
     allowed_datasets: list[str] | None = None,
     vector_search_enabled: bool | None = None,
@@ -179,6 +188,7 @@ def _set_environment_overrides(
         "BIGQUERY_LIST_MAX_RESULTS_DETAILED": str(detailed_list_max) if detailed_list_max is not None else None,
         "BIGQUERY_SAMPLE_ROWS": str(sample_rows) if sample_rows is not None else None,
         "BIGQUERY_SAMPLE_ROWS_FOR_STATS": str(stats_sample_size) if stats_sample_size is not None else None,
+        "BIGQUERY_MAX_BYTES_BILLED": str(max_bytes_billed) if max_bytes_billed is not None else None,
         "GOOGLE_APPLICATION_CREDENTIALS": key_file,
         "BIGQUERY_ALLOWED_DATASETS": ",".join(allowed_datasets) if allowed_datasets else None,
         "BIGQUERY_VECTOR_SEARCH_ENABLED": str(vector_search_enabled).lower()
@@ -203,6 +213,7 @@ def run_server(
     detailed_list_max: int | None = None,
     sample_rows: int | None = None,
     stats_sample_size: int | None = None,
+    max_bytes_billed: int | None = None,
     allowed_datasets: list[str] | None = None,
     check_auth_only: bool = False,
     vector_search_enabled: bool | None = None,
@@ -221,6 +232,7 @@ def run_server(
         detailed_list_max: Optional override for detailed list max results
         sample_rows: Optional override for sample data rows
         stats_sample_size: Optional override for stats sampling size
+        max_bytes_billed: Optional override for max bytes billed per query job
         allowed_datasets: Optional list of allowed dataset IDs
         check_auth_only: If True, only check authentication and exit
         vector_search_enabled: Optional override for vector search enabled/disabled
@@ -235,6 +247,7 @@ def run_server(
         detailed_list_max=detailed_list_max,
         sample_rows=sample_rows,
         stats_sample_size=stats_sample_size,
+        max_bytes_billed=max_bytes_billed,
         key_file=key_file,
         allowed_datasets=allowed_datasets,
         vector_search_enabled=vector_search_enabled,
@@ -339,6 +352,7 @@ def main() -> None:
             detailed_list_max=args.detailed_list_max,
             sample_rows=args.sample_rows,
             stats_sample_size=args.stats_sample_size,
+            max_bytes_billed=args.max_bytes_billed,
             allowed_datasets=args.allowed_datasets,
             check_auth_only=args.check_auth,
             vector_search_enabled=args.vector_search_enabled,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -99,9 +99,10 @@ def test_allowed_datasets_empty_env_var():
         ("detailed_list_max", "BIGQUERY_LIST_MAX_RESULTS_DETAILED", int),
         ("sample_rows", "BIGQUERY_SAMPLE_ROWS", int),
         ("stats_sample_size", "BIGQUERY_SAMPLE_ROWS_FOR_STATS", int),
+        ("max_bytes_billed", "BIGQUERY_MAX_BYTES_BILLED", int),
     ],
 )
-def test_server_environment_variable_handling(arg_name, env_var, expected_type):
+def test_server_environment_variable_handling(arg_name, env_var, expected_type, monkeypatch):
     """Test that server correctly handles environment variables for configuration."""
     from bigquery_mcp.server import _set_environment_overrides
 
@@ -109,9 +110,7 @@ def test_server_environment_variable_handling(arg_name, env_var, expected_type):
     test_value = 100
     kwargs = {arg_name: test_value}
 
-    # Clear any existing value
-    if env_var in os.environ:
-        del os.environ[env_var]
+    monkeypatch.delenv(env_var, raising=False)
 
     # Call the function
     _set_environment_overrides(**kwargs)
@@ -142,6 +141,7 @@ def test_configuration_defaults(env_vars):
     from bigquery_mcp.bigquery_tools import (
         DEFAULT_LIST_MAX_RESULTS,
         DEFAULT_LIST_MAX_RESULTS_DETAILED,
+        DEFAULT_MAX_BYTES_BILLED,
         DEFAULT_SAMPLE_ROWS,
         DEFAULT_SAMPLE_ROWS_FOR_STATS,
     )
@@ -151,3 +151,4 @@ def test_configuration_defaults(env_vars):
     assert DEFAULT_LIST_MAX_RESULTS_DETAILED == 25
     assert DEFAULT_SAMPLE_ROWS == 3
     assert DEFAULT_SAMPLE_ROWS_FOR_STATS == 500
+    assert DEFAULT_MAX_BYTES_BILLED == 109951162777

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,6 +1,6 @@
 """Essential unit tests for BigQuery MCP Server focusing on safety and error handling."""
 
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 from google.cloud.exceptions import GoogleCloudError
@@ -90,6 +90,44 @@ async def test_run_query_bigquery_error():
     assert "Test error" in result["error"]
     # GoogleCloudError gets mapped to GoogleAPICallError in the actual implementation
     assert result["error_type"] in ["GoogleCloudError", "GoogleAPICallError"]
+
+
+@pytest.mark.asyncio
+async def test_run_query_applies_maximum_bytes_billed(monkeypatch):
+    """Test that run_query sets maximum_bytes_billed on query jobs."""
+    monkeypatch.setenv("BIGQUERY_MAX_BYTES_BILLED", "123456")
+
+    from bigquery_mcp.bigquery_tools import register_tools
+
+    tools = {}
+
+    def mock_tool(fn=None, *, description=None):
+        def decorator(func):
+            tools[func.__name__] = func
+            return func
+
+        return decorator(fn) if fn else decorator
+
+    mcp = Mock()
+    mcp.tool = mock_tool
+
+    mock_bigquery_client = Mock()
+    mock_query_job = Mock()
+    mock_results = MagicMock()
+    mock_results.total_rows = 0
+    mock_results.__iter__.return_value = iter([])
+    mock_query_job.result.return_value = mock_results
+    mock_query_job.total_bytes_processed = 42
+    mock_bigquery_client.query.return_value = mock_query_job
+
+    register_tools(mcp, mock_bigquery_client)
+
+    run_query = tools["run_query"]
+    result = await run_query("SELECT 1")
+
+    assert result["success"] is True
+    job_config = mock_bigquery_client.query.call_args.kwargs["job_config"]
+    assert job_config.maximum_bytes_billed == 123456
 
 
 @pytest.mark.asyncio

--- a/tests/test_vector_search.py
+++ b/tests/test_vector_search.py
@@ -125,6 +125,7 @@ async def test_vector_search_basic_functionality(mock_mcp_and_client, monkeypatc
     monkeypatch.setenv("BIGQUERY_VECTOR_SEARCH_ENABLED", "true")
     monkeypatch.setenv("BIGQUERY_EMBEDDING_MODEL", "my_project.my_dataset.my_model")
     monkeypatch.setenv("BIGQUERY_EMBEDDING_COLUMN_CONTAINS", "embedding")
+    monkeypatch.setenv("BIGQUERY_MAX_BYTES_BILLED", "654321")
 
     from bigquery_mcp.bigquery_tools import register_tools
 
@@ -158,6 +159,8 @@ async def test_vector_search_basic_functionality(mock_mcp_and_client, monkeypatc
     call_args = mock_bigquery_client.query.call_args[0][0]
     assert "VECTOR_SEARCH" in call_args
     assert "ML.GENERATE_EMBEDDING" in call_args
+    job_config = mock_bigquery_client.query.call_args.kwargs["job_config"]
+    assert job_config.maximum_bytes_billed == 654321
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

This adds a default BigQuery `maximum_bytes_billed` cap to query-executing tools so a single query cannot exceed roughly `$0.50` in on-demand scan cost by default.

At BigQuery's on-demand rate of `$5 / TiB`, that works out to a default cap of `109,951,162,777` bytes.

## Changes

- add `DEFAULT_MAX_BYTES_BILLED = 109951162777`
- centralize query job config creation so the cap is applied consistently
- apply the cap to:
  - `run_query`
  - table fill-rate sampling queries
  - table sample-data queries
  - vector-search discovery queries
  - vector-search execution queries
- expose configuration through:
  - `--max-bytes-billed`
  - `BIGQUERY_MAX_BYTES_BILLED`
- document the new default in the README
- keep the default easy to override for OSS users, CI, and public-dataset setups
- add regression tests for config wiring and query job config usage

## Testing

- `uv run ruff check src tests`
- `uv run pytest`
