### PR TITLE
docs: add BIGQUERY_MAX_BYTES_BILLED to example configs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,7 @@ BIGQUERY_ALLOWED_DATASETS=dataset1,dataset2,dataset3
 BIGQUERY_MAX_RESULTS=20                      # Max rows returned by run_query (default: 20)
 BIGQUERY_LIST_MAX_RESULTS=500                # Max results for basic list operations (default: 500)
 BIGQUERY_LIST_MAX_RESULTS_DETAILED=25        # Max results for detailed list operations (default: 25)
+BIGQUERY_MAX_BYTES_BILLED=21474836480        # Cap per-query spend; 20 GiB (~USD 0.10/query, $5/TiB)
 
 # Table Analysis Settings
 BIGQUERY_SAMPLE_ROWS=3                       # Sample data rows returned in get_table (default: 3)

--- a/.mcp.json
+++ b/.mcp.json
@@ -7,7 +7,9 @@
         "--project",
         "your-project-id",
         "--location",
-        "US"
+        "US",
+        "--max-bytes-billed",
+        "21474836480"
       ]
     }
   }


### PR DESCRIPTION
## Summary
- Add `BIGQUERY_MAX_BYTES_BILLED=21474836480` (20 GiB, ~USD 0.10/query at \$5/TiB) to `.env.example`
- Add matching `--max-bytes-billed 21474836480` to the example `.mcp.json`

Surfaces the per-query spend cap shipped in #7 in the copy-paste examples so users opt into a conservative default. The in-code default remains 100 GiB.

