### PR TITLE
chore: bump google-cloud-bigquery 3.31.0 → 3.41.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 dependencies = [
     "python-dotenv>=1.1.0",
     "fastmcp==2.13.0",
-    "google-cloud-bigquery==3.31.0",
+    "google-cloud-bigquery==3.41.0",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -103,7 +103,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "fastmcp", specifier = "==2.13.0" },
-    { name = "google-cloud-bigquery", specifier = "==3.31.0" },
+    { name = "google-cloud-bigquery", specifier = "==3.41.0" },
     { name = "python-dotenv", specifier = ">=1.1.0" },
 ]
 
@@ -502,7 +502,7 @@ wheels = [
 
 [[package]]
 name = "google-cloud-bigquery"
-version = "3.31.0"
+version = "3.41.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-api-core", extra = ["grpc"] },
@@ -513,9 +513,9 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/73/91/4c7274f4d5faf13ac000b06353deaf3579575bf0e4bbad07fa68b9f09ba9/google_cloud_bigquery-3.31.0.tar.gz", hash = "sha256:b89dc716dbe4abdb7a4f873f7050100287bc98514e0614c5d54cd6a8e9fb0991", size = 479961, upload-time = "2025-03-25T18:54:40.43Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/13/6515c7aab55a4a0cf708ffd309fb9af5bab54c13e32dc22c5acd6497193c/google_cloud_bigquery-3.41.0.tar.gz", hash = "sha256:2217e488b47ed576360c9b2cc07d59d883a54b83167c0ef37f915c26b01a06fe", size = 513434, upload-time = "2026-03-30T22:50:55.347Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e8/bc/4cb8c61fc6dd817a4a390b745ec7b305f4578f547a16d09d54c8a790624b/google_cloud_bigquery-3.31.0-py3-none-any.whl", hash = "sha256:97f4a3219854ff01d6a3a57312feecb0b6e13062226b823f867e2d3619c4787b", size = 250099, upload-time = "2025-03-25T18:54:38.241Z" },
+    { url = "https://files.pythonhosted.org/packages/40/33/1d3902efadef9194566d499d61507e1f038454e0b55499d2d7f8ab2a4fee/google_cloud_bigquery-3.41.0-py3-none-any.whl", hash = "sha256:2a5b5a737b401cbd824a6e5eac7554100b878668d908e6548836b5d8aaa4dcaa", size = 262343, upload-time = "2026-03-30T22:48:45.444Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bump `google-cloud-bigquery` pin from 3.31.0 to 3.41.0 (latest stable, minor)
- Lockfile regenerated

Minor version bump — no API surface used by this project has changed between 3.31 and 3.41.

## Test plan
- [x] `pytest` (non-integration): 43/43 passing against 3.41.0
- [x] `ruff check`, `ruff format --check`: clean
- [x] `mypy`: clean
- [ ] CI integration tests against real BigQuery

Note: local integration tests (9 in `tests/test_integration.py`) currently fail with `uv 0.8.14` due to an unrelated hatchling build-isolation bug — they fail identically on `master` before this change. CI should run them in a clean environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)