### PR TITLE
fix: pin packaging<26 in build-system to unblock builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,8 @@ dev = [
 ]
 
 [build-system]
-requires = ["hatchling"]
+# packaging 26.x ships broken (missing submodules); pin until upstream is fixed
+requires = ["hatchling", "packaging<26"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]


### PR DESCRIPTION
## Summary
Constrain `packaging<26` in `[build-system].requires` so the hatchling PEP 517 build env doesn't pull the broken `packaging==26.2` wheel.

## Root cause
- `hatchling==1.29.0` (latest) declares `packaging>=24.2`
- During isolated builds, uv resolves that to `packaging==26.2`
- `packaging==26.2` ships a broken wheel — only `__init__.py`, `version.py`, and `licenses/` are present. `requirements.py`, `markers.py`, `specifiers.py`, etc. are missing.
- Hatchling crashes with `ModuleNotFoundError: No module named 'packaging.requirements'`

This breaks `uv sync`, `uv build`, and any subprocess started via `uv run` — including all 9 tests in `tests/test_integration.py` which spawn the server via `uv run python -m src.bigquery_mcp.server`.

## Fix
Pin `packaging<26` in `[build-system].requires`. Forces the build env onto packaging 25.0 (last functional release).

## Test plan
- [x] `uv build --wheel` — succeeds
- [x] `uv sync` — succeeds
- [x] `pytest` — 52/52 passing (43 unit + 9 integration against real BigQuery)

🤖 Generated with [Claude Code](https://claude.com/claude-code)